### PR TITLE
Inline comments :: 'js':[],'css':[],'qweb':[]

### DIFF
--- a/prototype/templates/8.0/__openerp__.py.template
+++ b/prototype/templates/8.0/__openerp__.py.template
@@ -3,10 +3,15 @@
 {
     'name': '{{ prototype.name }}',
     'version': '{{ prototype.version }}',
+    
     'author': '{{ prototype.author }}',
     'maintainer': '{{ prototype.maintainer }}',
     'website': '{{ prototype.website }}',
     'license': '{{ prototype.licence }}',
+    
+    # Categories can be used to filter modules in modules listing
+    # Check https://github.com/odoo/odoo/blob/master/openerp/addons/base/module/module_data.xml
+    # for the full list
     'category': '{{ prototype.category_id.name }}',
     'summary': '{{ prototype.summary }}',
     'description': """
@@ -16,6 +21,8 @@
 * If you have any questions, please contact Savoir-faire Linux \
 (support@savoirfairelinux.com)
 """,
+
+    # any module necessary for this one to work correctly
     'depends': [
         {% for dependency in prototype.dependency_ids -%}
             '{{ dependency.name }}',
@@ -23,15 +30,27 @@
     'external_dependencies': {
         'python': [],
     },
+    
+    # always loaded
     'data': [
         {% for data_file in data_files -%}
             '{{ data_file }}',
         {% endfor -%}],
+    # only loaded in demonstration mode
     'demo': [
         {% for demo_file in prototype.demo_ids -%}
             '{{ demo_file.name }}',
         {% endfor -%}],
+    
+    # used for Javascript Web CLient Testing with QUnit / PhantomJS
+    # https://www.odoo.com/documentation/8.0/reference/javascript.html#testing-in-odoo-web-client
+    'js': [],
+    'css': [],
+    'qweb': [],
+
     'installable': True,
+    # Install this module automatically if all dependency have been previously and independently installed.
+    # Used for synergetic or glue modules.
     'auto_install': {{ prototype.auto_install }},
     'application': {{ prototype.application }},
 }


### PR DESCRIPTION
I propose to add inline comments for the following reason:

General understanding is promoted when reading the source files as probablyt the main entry point for a developer.
js,css,qweb are taken from other manifests I've seen. They are explained in the link. I think completedness of the manifest scaffold also helps reduce ambiguity about it.

Lastly, I introduced newlines for better readability and grouping.

I hope these changes, well (marginally) improve the usefulness of this great module.
