### PR TITLE
Added and override methods/views that generate files during export with external ids

### DIFF
--- a/module_prototyper/models/module_prototyper.py
+++ b/module_prototyper/models/module_prototyper.py
@@ -49,6 +49,7 @@ class IrFilter(models.Model):
 
 
 class ModulePrototyper(models.Model):
+
     """Module Prototyper gathers different information from all over the
     database to build a prototype of module.
     We are calling it a prototype as it will most likely need to be reviewed
@@ -224,7 +225,8 @@ class ModulePrototyper(models.Model):
     @api.model
     def set_keep_external_ids(self, bool):
         """Set the the keep_external_ids from the wizard
-        keep_external_ids will help to update all external ids or keep exsting ones.
+        keep_external_ids will help to update all external
+        ids or keep exsting ones.
         :param bool: bool, wizard's value
         """
         self.keep_external_ids = bool
@@ -760,10 +762,10 @@ class ModulePrototyper(models.Model):
                         # Save fields that possibly contains circular
                         # dependency
                         model_id = model_obj.search(
-                                            [['model', '=', model_name]]).id
+                            [['model', '=', model_name]]).id
                         field_id = fields_obj.search(
-                                            [['name', '=', f],
-                                             ['model_id', '=', model_id]])
+                            [['name', '=', f],
+                             ['model_id', '=', model_id]])
                         fields_dep.append(field_id.id)
 
         return fields_dep

--- a/module_prototyper/models/module_prototyper.py
+++ b/module_prototyper/models/module_prototyper.py
@@ -33,12 +33,19 @@ from jinja2 import Environment, FileSystemLoader
 
 from openerp import models, api, fields
 from openerp.tools.safe_eval import safe_eval
+from openerp.exceptions import ValidationError
 
 from . import licenses
 
 _logger = logging.getLogger(__name__)
 
 YEAR = date.today().year
+
+
+class IrFilter(models.Model):
+    _inherit = 'ir.filters'
+
+    sequence = fields.Integer()
 
 
 class ModulePrototyper(models.Model):
@@ -201,6 +208,7 @@ class ModulePrototyper(models.Model):
         help=('Enter the list of workflow transitions that you have created '
               'and want to export in this module')
     )
+    keep_external_ids = fields.Boolean(default=False)
 
     _env = None
     _data_files = ()
@@ -208,6 +216,19 @@ class ModulePrototyper(models.Model):
     _field_descriptions = None
     File_details = namedtuple('file_details', ['filename', 'filecontent'])
     template_path = '{}/../templates/'.format(os.path.dirname(__file__))
+    MAGIC_FIELDS_KEY = ["create_date", "create_uid", "write_uid", "id",
+                        "__last_update", "write_date", "display_name", "image"]
+    type_fields = ["xml", "html", "file", "char", "base64",
+                   "int", "float", "list", "tuple"]
+
+    @api.model
+    def set_keep_external_ids(self, bool):
+        """Set the the keep_external_ids from the wizard
+        keep_external_ids will help to update all external ids or keep exsting ones.
+        :param bool: bool, wizard's value
+        """
+        self.keep_external_ids = bool
+        pass
 
     @api.model
     def set_jinja_env(self, api_version):
@@ -247,7 +268,7 @@ class ModulePrototyper(models.Model):
             self._field_descriptions[field] = field_description
 
     @api.model
-    def generate_files(self):
+    def generate_files(self, fields_ignore=None):
         """ Generates the files from the details of the prototype.
         :return: tuple
         """
@@ -264,7 +285,7 @@ class ModulePrototyper(models.Model):
         file_details.extend(self.generate_views_details())
         file_details.extend(self.generate_menus_details())
         file_details.append(self.generate_module_init_file_details())
-        file_details.extend(self.generate_data_files())
+        file_details.extend(self.generate_data_files(fields_ignore))
         # must be the last as the other generations might add information
         # to put in the __openerp__: additional dependencies, views files, etc.
         file_details.append(self.generate_module_openerp_file_details())
@@ -425,8 +446,42 @@ class ModulePrototyper(models.Model):
             fields=field_descriptions,
         )
 
+    def topological_sort(self, items):
+        """
+        Items must be provided in the form of an iterable,
+        where the key has a tuple.
+        [
+        [item,[dependencies]],
+        [,[]],
+        [,[]]
+        ]
+        """
+        provided = set()
+        while items:
+            remaining_items = []
+            emitted = False
+
+            for item, dependencies, records in items:
+                #
+                # Definir el metodo que ignora los fields_diff
+                #
+                if dependencies.issubset(provided):
+                    yield item, records
+                    provided.add(item)
+                    emitted = True
+                else:
+                    remaining_items.append((item, dependencies, records))
+
+            if not emitted:
+                raise ValidationError('The dependency-aware sorting\
+                    (topological sort) of the model names faild.\
+                    Probably the algorythm is getting a circular dependency.\
+                    Please refer to the source code.')
+
+            items = remaining_items
+
     @api.model
-    def generate_data_files(self):
+    def generate_data_files(self, fields_ignore=None):
         """ Generate data and demo files """
         data, demo = {}, {}
         filters = [
@@ -444,13 +499,39 @@ class ModulePrototyper(models.Model):
             target[model] |= model_obj.search(safe_eval(ir_filter.domain))
 
         res = []
+
+        # Contains name of fields that will ignored
+        fields_obj = self.env['ir.model.fields']
+        fields_ignore_names = [field.name for field in
+                               fields_obj.browse(fields_ignore)]
+
         for prefix, model_data, file_list in [
                 ('data', data, self._data_files),
                 ('demo', demo, self._demo_files)]:
+
+            items = []
+            models = set(m for m, recs in model_data.iteritems())
+
             for model_name, records in model_data.iteritems():
+                if not records:
+                    raise ValidationError('There are no records\
+                     on a particular filter. Please check, that you\'re\
+                      only accessing filters that show records.')
+                dependencies = set()
+                for f in records._fields:
+                    if f in fields_ignore_names:
+                        continue
+                    d = records._fields[f].comodel_name
+                    if d is not None and d in models and d != model_name:
+                        dependencies.add(d)
+                # ensure unique values of comodel_types
+                items.append([model_name, dependencies, records])
+
+            for model_name, records in self.topological_sort(items):
                 fname = self.friendly_name(self.unprefix(model_name))
                 filename = '{0}/{1}.xml'.format(prefix, fname)
                 self._data_files.append(filename)
+                records = self.fixup_data(records)
 
                 res.append(self.generate_file_details(
                     filename,
@@ -513,6 +594,97 @@ class ModulePrototyper(models.Model):
 
         return lxml.etree.tostring(doc)
 
+    @classmethod
+    def order_data(cls, records):
+
+        x = max([r.id for r in records])
+
+        def key(record):
+            level = 0
+
+            if hasattr(record, 'parent_id'):
+                parent = record.parent_id or False
+
+                while parent:
+                    level += 1
+                    parent = hasattr(parent, 'parent_id') and parent.parent_id
+
+            return (level * x) + record.id
+
+        return records.sorted(key=key)
+
+    @api.model
+    def generate_external_id(self, records):
+        ir_model_data = records.sudo().env['ir.model.data']
+        i = 0
+        x = max([r.id for r in records])
+        n = len(str(x))
+
+        if not self.keep_external_ids:
+            delete = ir_model_data.search([('model', '=', records._name)])
+            delete.unlink()
+
+        for r in records:
+            i += 1
+            data = ir_model_data.search(
+                [('model', '=', r._name), ('res_id', '=', r.id)])
+
+            if data and self.keep_external_ids:
+                pass
+            elif not self.keep_external_ids:
+                name = '%s_%s' % (r._name.split(".").pop(), str(i).zfill(n))
+                ir_model_data.create({
+                    'model': r._name,
+                    'res_id': r.id,
+                    'module': self.name,
+                    'name': name,
+                })
+
+    @api.model
+    def fixup_data(cls, records):
+        records = cls.order_data(records)
+        cls.generate_external_id(records)
+
+        # http://odoo-80.readthedocs.org/en/latest/reference/data.html
+        # http://stackoverflow.com/questions/26011102/openerp-odoo-model-relationship-xml-syntax
+        # For simplicity, we might be able to work with the eval and the obj,
+        # that is available in the context and browse it by the id,
+        # that we already have
+
+        recs_lst = []
+        for r in records:
+            ext_id = r.get_external_id().values()[0]
+            fields_lst = []
+
+            for field, val in r.read()[0].iteritems():
+                if field in cls.MAGIC_FIELDS_KEY:
+                    continue
+
+                ref = False
+                field_type = False
+
+                # Only catch external ids, if it is a relational field
+                # TODO: Verify, if fields._RelationalMulti (One2many&Many2many)
+                # are also represented in an xml with the ref attribute
+                # Else there would need to be added an if statement which
+                # constructs the eval attribute accordingly.
+                if isinstance(r._fields[field], fields._Relational):
+                    ref = ",".join(r[field].get_external_id().values())
+                    val = False
+
+                # see:https://www.odoo.com/documentation/8.0/reference/data.html
+                if r.fields_get()[field]['type'] in cls.type_fields:
+                    field_type = r.fields_get()[field]['type']
+
+                fields_lst.append([field, val, ref, field_type])
+
+            # Ordering fields on each record in alfabetical order.
+            fields_lst = sorted(fields_lst, key=lambda k: k[0])
+            # add external id and fields list to rec_lst
+            recs_lst.extend([(ext_id, fields_lst)])
+
+        return sorted(recs_lst, key=lambda k: k[0])
+
     @api.model
     def generate_file_details(self, filename, template, **kwargs):
         """ generate file details from jinja2 template.
@@ -539,6 +711,62 @@ class ModulePrototyper(models.Model):
             }
         )
         return self.File_details(filename, template.render(kwargs))
+
+    @api.model
+    def deps_detect(self):
+        """ Detect depedencies of the data fields.
+        :return: list
+        """
+
+        assert self._env is not None, \
+            'Run set_env(api_version) before to generate files.'
+
+        self.generate_models_details()
+
+        data, demo = {}, {}
+        filters = [
+            (data, ir_filter)
+            for ir_filter in self.data_ids
+        ] + [
+            (demo, ir_filter)
+            for ir_filter in self.demo_ids
+        ]
+
+        for target, ir_filter in filters:
+            model = ir_filter.model_id
+            model_obj = self.env[model]
+            target.setdefault(model, model_obj.browse([]))
+            target[model] |= model_obj.search(safe_eval(ir_filter.domain))
+
+        fields_dep = []
+        fields_obj = self.env['ir.model.fields']
+        model_obj = self.env['ir.model']
+
+        for prefix, model_data, file_list in [
+                ('data', data, self._data_files),
+                ('demo', demo, self._demo_files)]:
+
+            models = set(m for m, recs in model_data.iteritems())
+
+            for model_name, records in model_data.iteritems():
+                if not records:
+                    raise ValidationError('There are no records on a\
+                                particular filter. Please check,\
+                                that you\'re only accessing filters\
+                                that show records.')
+                for f in records._fields:
+                    dep = records._fields[f].comodel_name
+                    if dep is not None and dep in models and dep != model_name:
+                        # Save fields that possibly contains circular
+                        # dependency
+                        model_id = model_obj.search(
+                                            [['model', '=', model_name]]).id
+                        field_id = fields_obj.search(
+                                            [['name', '=', f],
+                                             ['model_id', '=', model_id]])
+                        fields_dep.append(field_id.id)
+
+        return fields_dep
 
 
 # Utility functions for rendering templates

--- a/module_prototyper/templates/8.0/data/model_name.xml.template
+++ b/module_prototyper/templates/8.0/data/model_name.xml.template
@@ -1,8 +1,18 @@
 <?xml version="1.0"?>
 <openerp>
   <data>
+    {% for record in records %}
 
-      {{ data }}
+        <record id="{{ record[0] }}" model="{{ model }}">
+        {% for key, val, ref, field_type in record[1] %}
+          <field name="{{ key }}"{% if ref %} ref="{{ ref }}"{% endif %}{% if field_type %} type="{{ field_type }}"{% endif %}{% if val %}>{{ val }}</field>{% else %}/>{% endif %}
 
+        {% endfor %}
+        </record>
+
+        {% if not loop.last %}
+
+        {% endif %}
+    {% endfor %}
   </data>
 </openerp>

--- a/module_prototyper/wizard/module_prototyper_module_export.py
+++ b/module_prototyper/wizard/module_prototyper_module_export.py
@@ -152,7 +152,7 @@ class PrototypeModuleExport(models.TransientModel):
                     {
                         'fields_selected': [(6, 1, fields_dependencies,)],
                         'fields_selected_initial': [
-                                            (6, 1, fields_dependencies,)],
+                            (6, 1, fields_dependencies,)],
                         'state': 'dep',
                     }
                 )

--- a/module_prototyper/wizard/module_prototyper_module_export.py
+++ b/module_prototyper/wizard/module_prototyper_module_export.py
@@ -45,10 +45,77 @@ class PrototypeModuleExport(models.TransientModel):
     state = fields.Selection(
         [
             ('choose', 'choose'),  # choose version
+            ('dep', 'dep'),  # dependencies
             ('get', 'get')  # get module
         ],
         default='choose'
     )
+
+    keep_external_ids = fields.Boolean(
+        string="Preserve existing external IDs?",
+        help="""Useful, if you are using this module for
+        generating module data from different sources.
+        Keep for example, when shipping data updates
+        with this model. You may well need to still
+        manually clean up and mix in the results.""",
+        default=False
+    )
+
+    fields_selected = fields.Many2many(
+        string='Fields Selected',
+        required=False,
+        readonly=False,
+        index=False,
+        default=None,
+        help=False,
+        comodel_name='ir.model.fields',
+        domain=[],
+        context={},
+        limit=None,
+    )
+
+    fields_selected_initial = fields.Many2many(
+        string='Fields Selected Difference',
+        required=False,
+        readonly=False,
+        index=False,
+        default=None,
+        help=False,
+        comodel_name='ir.model.fields',
+        domain=[],
+        context={},
+        limit=None
+    )
+
+    fields_not_selected = fields.Many2many(
+        string='Fields Not Selected',
+        required=False,
+        readonly=False,
+        index=False,
+        default=None,
+        help=False,
+        comodel_name='ir.model.fields',
+        domain=[],
+        context={},
+        limit=None,
+        compute='_compute_fields_not_selected',
+    )
+
+    @api.one
+    @api.depends('fields_selected', 'fields_not_selected')
+    def _compute_fields_not_selected(self):
+        # Diferentes between fields initial and actual
+        fields_ini = [field.id for field in self.fields_selected_initial]
+        fields_act = [field.id for field in self.fields_selected]
+        self.fields_not_selected = list(set(fields_ini) - set(fields_act))
+
+    @api.one
+    @api.onchange('fields_not_selected')
+    def onchange_fields_not_selected(self):
+        # Reformate self.fields_selected (If change fields_not_selected)
+        fields_ini = [field.id for field in self.fields_selected_initial]
+        fields_diff = [field.id for field in self.fields_not_selected]
+        self.fields_selected = list(set(fields_ini) - set(fields_diff))
 
     @api.model
     def action_export(self, ids):
@@ -73,7 +140,40 @@ class PrototypeModuleExport(models.TransientModel):
             [self._context.get('active_id')]
         )
 
-        zip_details = self.zip_files(wizard, prototypes)
+        # Validate if are not evaluated the depedencies resolve
+        # if the wizard was execute and returned a wizard fields_diff exists
+        # if the method dep_resolve not detect ciclyc dependencies
+        # (not return a wizard) continue to export files.
+        if not wizard.fields_selected and wizard.state != "dep":
+            fields_dependencies = self.dep_resolve(wizard, prototypes)
+
+            if fields_dependencies:
+                wizard.write(
+                    {
+                        'fields_selected': [(6, 1, fields_dependencies,)],
+                        'fields_selected_initial': [
+                                            (6, 1, fields_dependencies,)],
+                        'state': 'dep',
+                    }
+                )
+
+                return {
+                    'type': 'ir.actions.act_window',
+                    'res_model': 'module_prototyper.module.export',
+                    'view_mode': 'form',
+                    'view_type': 'form',
+                    'res_id': wizard.id,
+                    'views': [(False, 'form')],
+                    'target': 'new',
+                    'context': self._context,
+                }
+
+        # Recive of context the fields_not_selected because it's a wizard
+        fields_ignore = []
+        if 'fields_not_selected' in self._context.keys():
+            fields_ignore = self._context['fields_not_selected'][0][2]
+
+        zip_details = self.zip_files(wizard, prototypes, fields_ignore)
 
         if len(prototypes) == 1:
             zip_name = prototypes[0].name
@@ -99,7 +199,7 @@ class PrototypeModuleExport(models.TransientModel):
         }
 
     @staticmethod
-    def zip_files(wizard, prototypes):
+    def zip_files(wizard, prototypes, fields_ignore=None):
         """Takes a set of file and zips them.
         :param file_details: tuple (filename, file_content)
         :return: tuple (zip_file, stringIO)
@@ -114,11 +214,15 @@ class PrototypeModuleExport(models.TransientModel):
                 # files with.
                 prototype.set_jinja_env(wizard.api_version)
 
+                # will let the user decide on the wizard wether he wants
+                # to kkep external ids of the modules data or set fresh ones
+                prototype.set_keep_external_ids(wizard.keep_external_ids)
+
                 # generate_files ask the prototype to investigate the input and
                 # to generate the file templates according to it.  zip_files,
                 # in another hand, put all the template files into a package
                 # ready to be saved by the user.
-                file_details = prototype.generate_files()
+                file_details = prototype.generate_files(fields_ignore)
                 for filename, file_content in file_details:
                     if isinstance(file_content, unicode):
                         file_content = file_content.encode('utf-8')
@@ -130,3 +234,18 @@ class PrototypeModuleExport(models.TransientModel):
                     target.writestr(info, file_content)
 
             return zip_details(zip_file=target, stringIO=out)
+
+    @api.model
+    def dep_resolve(self, wizard, prototypes):
+        # This method return a wizard if are ciclyc dependencies,
+        # else return void
+
+        fields = []
+
+        # Create a list with field that possible have ciclyc dependencies
+        for prototype in prototypes:
+            prototype.set_jinja_env(wizard.api_version)
+            prototype.set_keep_external_ids(wizard.keep_external_ids)
+            fields.extend(prototype.deps_detect())
+
+        return fields

--- a/module_prototyper/wizard/module_prototyper_module_export_view.xml
+++ b/module_prototyper/wizard/module_prototyper_module_export_view.xml
@@ -12,6 +12,7 @@
           <group string="Export Settings" states="choose" col="6">
             <group colspan="2">
               <field name="api_version"/>
+              <field name="keep_external_ids"/>
             </group>
             <group colspan="4">
             </group>
@@ -20,8 +21,40 @@
             <h2>Export Complete</h2>
             <p>Here is the exported module: <field name="data" readonly="1" filename="name"/></p>
           </div>
+          <div states="dep">
+            <h2>Circular dependency manual cleaning</h2>
+            <p>We cannot programmatically solve this task, so we need your manual interaction. What you see is a list of circular dependency fields candidates in the upper list and the list of excluded fields in the lower list. A circular dependency cannot be exported, so we need to break it up. A circular dependency is called when Field X of Model A refers to Model B and Field Y of Model B refers to model A, so A refers to B and B, in turn, also refers to A. This way we cannot sort ("toposort") records and files in the correct way and export will fail.</p>
+            <h4>Field Candidates:</h4>
+            <p>Please identify in this list all circular dependencies, if any. Once identified, please delete one member of the circular dependency "ring" of your choice. It doesn't really matter which one. The deleted fields will appear in the excluded list below.</p>
+            <field name="fields_selected" nolabel="1" widget="many2many" options="{'no_create': True}">
+              <tree>
+                <field name="display_name"/>
+                <field name="name"/>
+                <field name="field_description"/>
+                <field name="model_id"/>
+                <field name="ttype"/>
+              </tree>
+            </field>
+            <h5>Example: account.account &lt;-&gt; account.tax models: account.account have tax_ids field (related with account.tax) and account.tax have account_paid_id and account_collected_id fields (related with account.account). In this case it is necessary to exclude tax_ids or account_paid_id and account_collected_id. This will prevent circular dependency in xml export.</h5>
+            <field name="fields_selected_initial" invisible="1"/>
+            <br/>
+            <h4>List of excluded fields (during export):</h4>
+            <field name="fields_not_selected" options="{'no_create': True}">
+              <tree>
+                <field name="display_name"/>
+                <field name="name"/>
+                <field name="field_description"/>
+                <field name="model_id"/>
+                <field name="ttype"/>
+              </tree>
+            </field>
+          </div>
           <footer states="choose">
             <button name="action_export" string="Export" type="object" class="oe_highlight"/> or
+            <button special="cancel" string="Cancel" type="object" class="oe_link"/>
+          </footer>
+          <footer states="dep">
+            <button name="action_export" context="{'fields_not_selected':fields_not_selected}" string="Export" type="object" class="oe_highlight"/> or
             <button special="cancel" string="Cancel" type="object" class="oe_link"/>
           </footer>
           <footer states="get">


### PR DESCRIPTION
Updated:
- module_prototyper/models/module_prototyper.py: 
  - Added set_keep_external_ids method: Set the the keep_external_ids from the wizard keep_external_ids will help to update all external ids or keep exsting ones.
  - Added topological_sort method: Items must be provided in the form of an iterable, where the key has a tuple.
  - Modify generate_data_files method: Added code to contruct a better data file.
  - Added order_data method: Create a hierarchy to export external ids, using a level dependent of parent.
  - Added generate_external_id method: Create all external ids to later export.
  - Added fixup_data method: Order, generate external ids and load all data to export.
  - Added deps_detect method: Detect depedencies on the data fields.
  - Add fields_ignore to some methods: This variable transport a information related by "Circular dependency cleaning" from wizard 'volatile" to export methods.
- module_prototyper/wizard/module_prototyper_module_export.py:
  - Added fields (keep_external_ids, fields_selected, fields_selected_initial, fields_not_selected): Keep_external_ids guaranted that the external_ids in the database are not rewrite when export module. fields_selected\* is used to store the cleanup data when exists a circular dependency.
  - dep_solve, action export, zip_files override: This override guaranted the correct "circular dependency cleaning" in exporting methods (see fields_ignore).
- module_prototyper/wizard/module_prototyper_module_export_view.xml: 
  - Added fields_selected, fields_selected_initial, fields_not_selected to the export wizard.
- module_prototyper/templates/8.0/data/model_name.xml.template: 
  - Added logic to generate fields with all addtional information.

@blaggacao Please explain better
